### PR TITLE
Fixed grilled food consumption bug

### DIFF
--- a/fabric/src/main/java/net/satisfy/camping/mixin/FabricPlayerEatMixin.java
+++ b/fabric/src/main/java/net/satisfy/camping/mixin/FabricPlayerEatMixin.java
@@ -13,12 +13,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Player.class)
 public abstract class FabricPlayerEatMixin {
-    @Inject(method="eat(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/food/FoodProperties;)Lnet/minecraft/world/item/ItemStack;", at=@At("HEAD"), cancellable=true)
+    @Inject(method="eat(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/food/FoodProperties;)Lnet/minecraft/world/item/ItemStack;", at=@At("TAIL"))
     private void camping$eat(Level level, ItemStack stack, FoodProperties props, CallbackInfoReturnable<ItemStack> cir) {
         if (!FabricCampingConfig.enableGrilling || !GrillingUtil.isGrilled(stack)) return;
         Player self=(Player)(Object)this;
         GrillingUtil.FoodValue extra=GrillingUtil.getAdditionalFoodValue(stack);
         self.getFoodData().eat((int)(props.nutrition()*1.25)+extra.nutrition(), props.saturation()*1.25F+extra.saturationModifier());
-        cir.setReturnValue(stack);
     }
 }


### PR DESCRIPTION
Fixed a bug where eating grilled food does not decrement it from the stack or remove it from the player's inventory.

Eating grilled food now properly removes an instance of the food item.