### PR TITLE
Fixed grilled food stats displaying improperly

### DIFF
--- a/common/src/main/java/net/satisfy/camping/core/util/GrillingUtil.java
+++ b/common/src/main/java/net/satisfy/camping/core/util/GrillingUtil.java
@@ -39,7 +39,15 @@ public class GrillingUtil {
         FoodProperties food = itemStack.get(DataComponents.FOOD);
         if (food != null) {
             int newNutrition = (int) (food.nutrition() * 1.25);
-            float newSaturation = food.saturation() * 1.25F;
+            float newSaturation = food.saturation() / (food.nutrition() * 2); // satpts = nutr * satmod * 2
+
+            FoodProperties boosted = new FoodProperties.Builder()
+                    .nutrition(newNutrition)
+                    .saturationModifier(newSaturation)
+                    .build();
+
+            itemStack.set(DataComponents.FOOD, boosted);
+
             CompoundTag tag = getOrCreateData(itemStack);
             tag.putInt(NUTRITION_KEY, newNutrition);
             tag.putFloat(SATURATION_KEY, newSaturation);

--- a/fabric/src/main/java/net/satisfy/camping/mixin/FabricPlayerEatMixin.java
+++ b/fabric/src/main/java/net/satisfy/camping/mixin/FabricPlayerEatMixin.java
@@ -17,7 +17,7 @@ public abstract class FabricPlayerEatMixin {
     private void camping$eat(Level level, ItemStack stack, FoodProperties props, CallbackInfoReturnable<ItemStack> cir) {
         if (!FabricCampingConfig.enableGrilling || !GrillingUtil.isGrilled(stack)) return;
         Player self=(Player)(Object)this;
-        GrillingUtil.FoodValue extra=GrillingUtil.getAdditionalFoodValue(stack);
-        self.getFoodData().eat((int)(props.nutrition()*1.25)+extra.nutrition(), props.saturation()*1.25F+extra.saturationModifier());
+        GrillingUtil.FoodValue extra = GrillingUtil.getAdditionalFoodValue(stack);
+        self.getFoodData().eat(extra.nutrition(), extra.saturationModifier());
     }
 }


### PR DESCRIPTION
Fixed a bug where eating grilled food would give max nutrition and saturation instead of a 25% increase.

Fixed a bug where nutrition and saturation were being displayed incorrectly in mods like Appleskin.