### PR TITLE
Fixed incorrect backpack/bag drop on destroy

### DIFF
--- a/common/src/main/java/net/satisfy/camping/core/util/GrillingUtil.java
+++ b/common/src/main/java/net/satisfy/camping/core/util/GrillingUtil.java
@@ -39,7 +39,15 @@ public class GrillingUtil {
         FoodProperties food = itemStack.get(DataComponents.FOOD);
         if (food != null) {
             int newNutrition = (int) (food.nutrition() * 1.25);
-            float newSaturation = food.saturation() * 1.25F;
+            float newSaturation = food.saturation() / (food.nutrition() * 2); // satpts = nutr * satmod * 2
+
+            FoodProperties boosted = new FoodProperties.Builder()
+                    .nutrition(newNutrition)
+                    .saturationModifier(newSaturation)
+                    .build();
+
+            itemStack.set(DataComponents.FOOD, boosted);
+
             CompoundTag tag = getOrCreateData(itemStack);
             tag.putInt(NUTRITION_KEY, newNutrition);
             tag.putFloat(SATURATION_KEY, newSaturation);

--- a/common/src/main/java/net/satisfy/camping/core/world/block/BackpackBlock.java
+++ b/common/src/main/java/net/satisfy/camping/core/world/block/BackpackBlock.java
@@ -38,6 +38,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.satisfy.camping.core.registry.CampingItems;
 import net.satisfy.camping.core.util.BackpackVariant;
 import net.satisfy.camping.core.util.CampingUtil;
+import net.satisfy.camping.core.util.EnderpackVariant;
 import net.satisfy.camping.core.world.BackpackContainer;
 import net.satisfy.camping.core.world.block.entity.BackpackBlockEntity;
 import org.jetbrains.annotations.NotNull;
@@ -187,6 +188,7 @@ public class BackpackBlock extends BaseEntityBlock implements SimpleWaterloggedB
         BlockEntity be = level.getBlockEntity(pos);
         if (be instanceof BackpackBlockEntity backpack) {
             if (player.isShiftKeyDown()) {
+                dropBlockWithContents(level, pos, backpack);
                 level.destroyBlock(pos, false);
                 return InteractionResult.CONSUME;
             }

--- a/common/src/main/java/net/satisfy/camping/core/world/block/EnderpackBlock.java
+++ b/common/src/main/java/net/satisfy/camping/core/world/block/EnderpackBlock.java
@@ -151,9 +151,6 @@ public class EnderpackBlock extends BaseEntityBlock implements SimpleWaterlogged
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
         if (!level.isClientSide && !state.is(newState.getBlock())) {
             BlockEntity be = level.getBlockEntity(pos);
-            if (be instanceof EnderpackBlockEntity enderpack) {
-                dropSelf(level, pos, enderpack);
-            }
         }
         super.onRemove(state, level, pos, newState, isMoving);
     }

--- a/fabric/src/main/java/net/satisfy/camping/mixin/FabricPlayerEatMixin.java
+++ b/fabric/src/main/java/net/satisfy/camping/mixin/FabricPlayerEatMixin.java
@@ -17,7 +17,7 @@ public abstract class FabricPlayerEatMixin {
     private void camping$eat(Level level, ItemStack stack, FoodProperties props, CallbackInfoReturnable<ItemStack> cir) {
         if (!FabricCampingConfig.enableGrilling || !GrillingUtil.isGrilled(stack)) return;
         Player self=(Player)(Object)this;
-        GrillingUtil.FoodValue extra=GrillingUtil.getAdditionalFoodValue(stack);
-        self.getFoodData().eat((int)(props.nutrition()*1.25)+extra.nutrition(), props.saturation()*1.25F+extra.saturationModifier());
+        GrillingUtil.FoodValue extra = GrillingUtil.getAdditionalFoodValue(stack);
+        self.getFoodData().eat(extra.nutrition(), extra.saturationModifier());
     }
 }


### PR DESCRIPTION
Fixed a bug where normal backpacks drop nothing on shift right-click and enderpacks/bags drop twice on destroy (both left-click and shift right-click).